### PR TITLE
feat: Bump up minimum API level to 24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.example.bluecatapp"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Bumped up due to limitations when working with date time formats. SimpleDateFormat requires API level 24.

DateTimeFormatter requires API level 26, but this can be considered in future if further needs arise.