### PR TITLE
Blocking app MVP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,11 +25,13 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.core:core-ktx:1.0.2'
+    implementation "androidx.preference:preference-ktx:1.1.0"
     implementation 'com.google.android.gms:play-services-location:17.0.0'
     implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.navigation:navigation-fragment:2.0.0'
     implementation 'androidx.navigation:navigation-ui:2.0.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,10 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.bluecatapp">
+
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
-
     <uses-permission
         android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
@@ -17,6 +17,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <service android:name=".AppBlockForegroundService" />
+
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission
         android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />

--- a/app/src/main/java/com/example/bluecatapp/AppBlockForegroundService.kt
+++ b/app/src/main/java/com/example/bluecatapp/AppBlockForegroundService.kt
@@ -1,0 +1,67 @@
+package com.example.bluecatapp
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+class AppBlockForegroundService : Service() {
+    private val CHANNEL_ID = "AppBlockForegroundService"
+
+    companion object {
+        fun startService(context: Context, message: String) {
+            val startIntent = Intent(context, AppBlockForegroundService::class.java)
+            startIntent.putExtra("inputExtra", message)
+            ContextCompat.startForegroundService(context, startIntent)
+        }
+
+        fun stopService(context: Context) {
+            val stopIntent = Intent(context, AppBlockForegroundService::class.java)
+            context.stopService(stopIntent)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+
+        val input = intent?.getStringExtra("inputExtra")
+        createNotificationChannel()
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0)
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("App blocking notifications")
+            .setContentText(input)
+            .setSmallIcon(R.drawable.ic_hourglass_empty_black_24dp)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        startForeground(1, notification)
+        return START_NOT_STICKY
+
+    }
+
+
+    private fun createNotificationChannel() {
+        // Create a notification channel for these notifications if supported (sdk over Oreo)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val serviceChannel = NotificationChannel(
+                CHANNEL_ID,
+                "AppBlock Foreground Service Channel",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager!!.createNotificationChannel(serviceChannel)
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+}

--- a/app/src/main/java/com/example/bluecatapp/AppBlockForegroundService.kt
+++ b/app/src/main/java/com/example/bluecatapp/AppBlockForegroundService.kt
@@ -1,18 +1,30 @@
 package com.example.bluecatapp
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
+import android.app.*
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
+import com.google.gson.reflect.TypeToken
+import android.text.TextUtils
+import android.util.Log
 
 class AppBlockForegroundService : Service() {
     private val CHANNEL_ID = "AppBlockForegroundService"
+    private lateinit var appOps: AppOpsManager
+    private lateinit var usage: UsageStatsManager
+    private lateinit var handler: Handler
+    private lateinit var runnable: Runnable
+    private val UPDATE_INTERVAL: Long = 1000
+    private lateinit var sharedPrefs: SharedPreferences
+    private var prevDetectedForegroundAppPackageName: String? = null
 
     companion object {
         fun startService(context: Context, message: String) {
@@ -27,13 +39,27 @@ class AppBlockForegroundService : Service() {
         }
     }
 
+    override fun onCreate() {
+        super.onCreate()
+        appOps = getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d("bcat", "Started app blocking service.")
 
         val input = intent?.getStringExtra("inputExtra")
         createNotificationChannel()
-        val notificationIntent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0)
+        val notificationIntent = Intent(this, MainActivity::class.java).putExtra(
+            "frgToLoad", FragmentToLoad.APPBLOCK
+        )
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            notificationIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
 
+        // Create persistent notification so that process should stay alive
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("App blocking notifications")
             .setContentText(input)
@@ -42,10 +68,25 @@ class AppBlockForegroundService : Service() {
             .build()
 
         startForeground(1, notification)
+
+        // Keep checking if we should block the current app
+        handler = Handler()
+        runnable = Runnable {
+            checkIfShouldBlockForegroundApp()
+            handler.postDelayed(runnable, UPDATE_INTERVAL)
+            getForegroundApp()?.let { retryBlockIfFailed(it) }
+        }
+        handler.postDelayed(runnable, UPDATE_INTERVAL)
+
         return START_NOT_STICKY
 
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("bcat", "App blocking service destroyed.")
+        handler.removeCallbacks(runnable)
+    }
 
     private fun createNotificationChannel() {
         // Create a notification channel for these notifications if supported (sdk over Oreo)
@@ -53,7 +94,7 @@ class AppBlockForegroundService : Service() {
             val serviceChannel = NotificationChannel(
                 CHANNEL_ID,
                 "AppBlock Foreground Service Channel",
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_LOW
             )
 
             val notificationManager = getSystemService(NotificationManager::class.java)
@@ -63,5 +104,97 @@ class AppBlockForegroundService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
+    }
+
+    private fun hasUsageDataAccessPermission(): Boolean {
+        val mode = appOps.checkOpNoThrow(
+            AppOpsManager.OPSTR_GET_USAGE_STATS,
+            android.os.Process.myUid(),
+            this.packageName
+        )
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    private fun getForegroundApp(): String? {
+        var foregroundPackageName: String? = null
+        usage = getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+        val endTime = System.currentTimeMillis()
+        val beginTime = endTime - (1 * 60 * 1000)
+
+        val usageEvents = usage.queryEvents(beginTime, endTime)
+        val event: UsageEvents.Event = UsageEvents.Event()
+
+        while (usageEvents.hasNextEvent()) {
+            usageEvents.getNextEvent(event)
+            if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+                foregroundPackageName = event.packageName
+            }
+        }
+        return foregroundPackageName
+    }
+
+    private fun getCurrentlyBlockedApps(): MutableMap<String, Long>? {
+        val type = object : TypeToken<MutableMap<String, Long>>() {}.type
+        sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val blockedAppsJson = sharedPrefs.getString("currentlyBlockedApps", null)
+        val currentlyBlockedApps: MutableMap<String, Long>? =
+            if (blockedAppsJson !== null) MainActivity.gson.fromJson(
+                blockedAppsJson,
+                type
+            ) else null
+        return currentlyBlockedApps
+    }
+
+    private fun blockApp(packageName: String) {
+        Log.d(
+            "bcat",
+            "Attempting to block app $packageName"
+        )
+        application.startActivity(
+            Intent(this, MainActivity::class.java).putExtra(
+                "frgToLoad",
+                FragmentToLoad.APPBLOCK
+            ).putExtra("blockedAppName", packageName).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+    }
+
+    private fun checkIfShouldBlockForegroundApp() {
+        val currentlyBlockedApps = getCurrentlyBlockedApps()
+        if (currentlyBlockedApps !== null) {
+            if (hasUsageDataAccessPermission()) {
+                val foregroundApp = getForegroundApp()
+                Log.d(
+                    "bcat",
+                    "CHECK - ${if (!prevDetectedForegroundAppPackageName.equals(foregroundApp)) "APP CHANGED - " else ""}Prev app $prevDetectedForegroundAppPackageName, current app open $foregroundApp"
+                )
+                if (!prevDetectedForegroundAppPackageName.equals(foregroundApp)) {
+                    // A new app has been opened, check if it should be blocked
+                    Log.d(
+                        "bcat",
+                        "App changed, block? ${if (currentlyBlockedApps.keys.contains(foregroundApp)) "YES" else "No"}"
+                    )
+                    if (currentlyBlockedApps.keys.contains(foregroundApp)) {
+                        foregroundApp?.let { blockApp(it) }
+                    }
+                }
+                if (!TextUtils.isEmpty(foregroundApp)) {
+                    prevDetectedForegroundAppPackageName = foregroundApp
+                }
+            }
+        }
+    }
+
+    private fun retryBlockIfFailed(packageName: String) {
+        val currentlyBlockedApps = getCurrentlyBlockedApps()
+        if (currentlyBlockedApps != null) {
+
+            if (currentlyBlockedApps.keys.contains(packageName)) {
+                Log.d(
+                    "bcat",
+                    "Retry blocking $packageName"
+                )
+                blockApp(packageName)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/bluecatapp/MainActivity.kt
+++ b/app/src/main/java/com/example/bluecatapp/MainActivity.kt
@@ -1,12 +1,14 @@
 package com.example.bluecatapp
 
 import android.os.Bundle
+import android.util.Log
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.gson.Gson
 
 object FragmentToLoad {
     val TODO = 0
@@ -16,6 +18,10 @@ object FragmentToLoad {
 }
 
 class MainActivity : AppCompatActivity() {
+
+    companion object {
+        val gson = Gson()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/bluecatapp/MainActivity.kt
+++ b/app/src/main/java/com/example/bluecatapp/MainActivity.kt
@@ -8,6 +8,13 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 
+object FragmentToLoad {
+    val TODO = 0
+    val APPBLOCK = 1
+    val LOCATION = 2
+    val SETTINGS = 3
+}
+
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,10 +27,20 @@ class MainActivity : AppCompatActivity() {
         // menu should be considered as top level destinations.
         val appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.navigation_todo, R.id.navigation_appblocking, R.id.navigation_location, R.id.navigation_settings
+                R.id.navigation_todo,
+                R.id.navigation_appblocking,
+                R.id.navigation_location,
+                R.id.navigation_settings
             )
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
+
+        when (intent.extras?.getInt("frgToLoad")) {
+            0 -> navController.navigate(R.id.navigation_todo)
+            1 -> navController.navigate(R.id.navigation_appblocking)
+            2 -> navController.navigate(R.id.navigation_location)
+            3 -> navController.navigate(R.id.navigation_settings)
+        }
     }
 }

--- a/app/src/main/java/com/example/bluecatapp/ui/appblocking/AppBlockingFragment.kt
+++ b/app/src/main/java/com/example/bluecatapp/ui/appblocking/AppBlockingFragment.kt
@@ -2,42 +2,41 @@ package com.example.bluecatapp.ui.appblocking
 
 import android.app.AlertDialog
 import android.app.AppOpsManager
-import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.icu.util.Calendar
 import android.os.Bundle
+import android.provider.Settings
+import android.text.SpannableStringBuilder
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.TextView
+import android.widget.Toast
+import androidx.core.text.bold
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
-import com.example.bluecatapp.R
-import android.util.Log
-import android.provider.Settings
-import android.content.Context
-import android.content.Intent
-import android.text.SpannableStringBuilder
-import android.widget.Toast
-import androidx.core.text.bold
-import android.content.pm.PackageManager
-import com.example.bluecatapp.FragmentToLoad
+import androidx.preference.PreferenceManager
+import com.example.bluecatapp.AppBlockForegroundService
 import com.example.bluecatapp.MainActivity
+import com.example.bluecatapp.R
 
 class AppBlockingFragment : Fragment() {
     private lateinit var appOps: AppOpsManager
     private lateinit var appBlockingViewModel: AppBlockingViewModel
     private lateinit var usage: UsageStatsManager
     private lateinit var packageManager: PackageManager
-    private lateinit var appsToBlock: MutableList<String>
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
-        appOps = context?.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
         usage = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
         packageManager = context.packageManager
-
-        // TODO: Implement some kind of background service that will check repeatedly if the app in the foreground should be blocked.
     }
 
     override fun onCreateView(
@@ -52,6 +51,15 @@ class AppBlockingFragment : Fragment() {
         appBlockingViewModel.text.observe(this, Observer {
             textView.text = it
         })
+        val startButton: Button = root.findViewById(R.id.start_foreground_service)
+        val stopButton: Button = root.findViewById(R.id.stop_foreground_service)
+
+        startButton.setOnClickListener {
+            AppBlockForegroundService.startService(context!!, "Monitoring.. ")
+        }
+        stopButton.setOnClickListener {
+            AppBlockForegroundService.stopService(context!!)
+        }
 
         return root
 
@@ -65,36 +73,15 @@ class AppBlockingFragment : Fragment() {
             // Permission is not granted, show alert dialog to request for permission
             showAlertDialog()
         }
-        appsToBlock = mutableListOf("com.android.chrome", "com.google.android.youtube")
-        if (hasUsageDataAccessPermission()) {
-
-            var currentApp: UsageStats? = null
-            val currentTime = System.currentTimeMillis()
-            val events: MutableList<UsageStats> =
-                usage.queryUsageStats(
-                    UsageStatsManager.INTERVAL_DAILY,
-                    currentTime - 1000 * 100,
-                    currentTime
-                )
-            events.sortBy { currentTime - it.lastTimeStamp }
-            val filteredUsageStats = events.filter {
-                appsToBlock.contains(it.packageName)
-            }
-            filteredUsageStats.forEach {
-                // Debug logging
-                Log.d(
-                    "bcat", "${it.packageName} ${currentTime - it.lastTimeStamp}"
-                )
-            }
-            currentApp = filteredUsageStats[0]
-
-            val blockedAppNameView: TextView = activity!!.findViewById(R.id.text_appblocking_data)
-            blockedAppNameView.text = packageManager.getApplicationLabel(
-                packageManager.getApplicationInfo(
-                    currentApp.packageName,
-                    0
-                )
-            )
+        val blockDuration: Long = Calendar.getInstance().timeInMillis + 1200000
+        val currentlyBlockedApps: MutableMap<String, Long> = mutableMapOf(
+            "com.android.chrome" to blockDuration,
+            "com.google.android.youtube" to blockDuration
+        )
+        val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
+        with(sharedPrefs.edit()) {
+            putString("currentlyBlockedApps", MainActivity.gson.toJson(currentlyBlockedApps))
+            commit()
         }
     }
 
@@ -144,13 +131,7 @@ class AppBlockingFragment : Fragment() {
     }
 
     private fun blockApp() {
-        // TODO: Use this function for blocking app through background service.
-        startActivity(
-            Intent(context, MainActivity::class.java).putExtra(
-                "frgToLoad",
-                FragmentToLoad.APPBLOCK
-            )
-        )
+        // TODO: Use this function for showing user info about blocked app
     }
 }
 

--- a/app/src/main/res/layout/fragment_appblocking.xml
+++ b/app/src/main/res/layout/fragment_appblocking.xml
@@ -31,4 +31,32 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/text_appblocking" />
 
+    <Button
+        android:id="@+id/start_foreground_service"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:background="@color/colorPrimary"
+        android:text="Start service"
+        android:textColor="#fff"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_appblocking_data" />
+
+    <Button
+        android:id="@+id/stop_foreground_service"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="400dp"
+        android:background="@color/colorPrimary"
+        android:onClick="onStopServiceClick"
+        android:text="Stop service"
+        android:textColor="#fff"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_appblocking.xml
+++ b/app/src/main/res/layout/fragment_appblocking.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -16,4 +17,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/text_appblocking_data"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_appblocking" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #7
> Comment 21.10.19: Just laying the groundwork for this app blocking feature was an incredibly challenging task 🐙And soon it might be completely ruined because Google will stop letting Services start activities (which is how we effectively block apps).

Implement most basic app blocking functionality. Keeps a foreground service running through notification (as is required), and checks regularly if current app should be blocked.
Makes use of Handler to do the repeat work. Makes use of UsageStatsManager to find the foreground app. Uses SharedPreferences for sharing data between service and activity, which we should use for handling our settings as well. 

Some methods used are marked as deprecated from API level 29, but nothing we can do about that unless we want to have almost no devices supported by upgrading.

Limitations:
* Always blocked, no countdown yet on block
* Hardcoded to Chrome and YouTube

![AppBlockMVP](https://user-images.githubusercontent.com/25204035/67165929-be666800-f3c5-11e9-8eff-c75bbfddd5ad.gif)

