### PR TITLE
Feat/toggle appblock

### DIFF
--- a/app/src/main/java/com/example/bluecatapp/ui/appblocking/AppBlockingFragment.kt
+++ b/app/src/main/java/com/example/bluecatapp/ui/appblocking/AppBlockingFragment.kt
@@ -73,8 +73,8 @@ class AppBlockingFragment : Fragment() {
 //        appBlockingViewModel.text.observe(this, Observer {
 //            textView.text = it
 //        })
-        val startButton: Button = root.findViewById(R.id.start_foreground_service)
-        val stopButton: Button = root.findViewById(R.id.stop_foreground_service)
+//        val startButton: Button = root.findViewById(R.id.start_foreground_service)
+//        val stopButton: Button = root.findViewById(R.id.stop_foreground_service)
 
         //initialize app block views
         blockedAppName = root.findViewById(R.id.currently_blocked_app)
@@ -86,20 +86,23 @@ class AppBlockingFragment : Fragment() {
         pedometerLabel = root.findViewById(R.id.step_explanation)
         pedometerValue = root.findViewById(R.id.step_count)
 
-        startButton.setOnClickListener {
-            AppBlockForegroundService.startService(context!!, "Monitoring.. ")
-        }
-        stopButton.setOnClickListener {
+        val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val isEnabled = sharedPrefs.getBoolean(getString(R.string.appblock), false)
+
+        if(isEnabled){
+            AppBlockForegroundService.startService(context!!, "Monitoring...")
+        } else{
             AppBlockForegroundService.stopService(context!!)
         }
+
+//        startButton.setOnClickListener {
+//            AppBlockForegroundService.startService(context!!, "Monitoring.. ")
+//        }
+//        stopButton.setOnClickListener {
+//            AppBlockForegroundService.stopService(context!!)
+//        }
         if (currentlyBlockedApps.entries.count() == 0) {
             hideViews()
-//            blockedAppName.text = "No blocked apps at the moment"
-//            chrono.visibility = View.INVISIBLE
-//            blockTimeLabel.visibility = View.INVISIBLE
-//            pedometerTitle.visibility = View.INVISIBLE
-//            pedometerLabel.visibility = View.INVISIBLE
-//            pedometerValue.visibility = View.INVISIBLE
         } else {
             currentlyBlockedApps.forEach { (appPackageName, finishTimeStamp) ->
                 blockedAppName.setText(getAppNameFromPackage(appPackageName, context!!))

--- a/app/src/main/java/com/example/bluecatapp/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/bluecatapp/ui/settings/SettingsFragment.kt
@@ -2,8 +2,10 @@ package com.example.bluecatapp.ui.settings
 
 import android.content.Context
 import android.os.Bundle
+import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.preference.*
+import com.example.bluecatapp.AppBlockForegroundService
 import com.example.bluecatapp.R
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -14,14 +16,31 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val profilePreference = findPreference<EditTextPreference>(getString(R.string.profile))
         profilePreference?.summary = "Display Name"
 
-        //set default pedometer preference to "true"
-        val pedometerPreference = preferenceManager.findPreference<SwitchPreference>(getString(R.string.pedometer))
-        pedometerPreference?.setChecked(true)
-
-        //set default app blocking preference to "true"
         val appBlockPreference = preferenceManager.findPreference<SwitchPreference>(getString(R.string.appblock))
-        appBlockPreference?.setChecked(true)
-        //TODO: replace START and STOP buttons in app blocking screen
+        //app block monitoring starts automatically when toggled on
+        appBlockPreference?.setOnPreferenceChangeListener( object : Preference.OnPreferenceChangeListener {
+            override fun onPreferenceChange(preference: Preference?, newValue: Any?): Boolean {
+                if(!appBlockPreference.isChecked){
+                    //toggle on: app blocking enabled
+                    AppBlockForegroundService.startService(context!!, "Monitoring.. ")
+
+                    Toast.makeText(
+                        activity!!.applicationContext,
+                        "App blocking enabled",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                } else{
+                    //toggle off: app blocking disabled
+                    AppBlockForegroundService.stopService(context!!)
+                    Toast.makeText(
+                        activity!!.applicationContext,
+                        "App blocking disabled",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                return true
+            }
+        })
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference?) {

--- a/app/src/main/java/com/example/bluecatapp/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/bluecatapp/ui/settings/SettingsFragment.kt
@@ -15,9 +15,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
         profilePreference?.summary = "Display Name"
 
         //set default pedometer preference to "true"
-        PreferenceManager.setDefaultValues(this.context, R.xml.root_preferences, true);
         val pedometerPreference = preferenceManager.findPreference<SwitchPreference>(getString(R.string.pedometer))
         pedometerPreference?.setChecked(true)
+
+        //set default app blocking preference to "true"
+        val appBlockPreference = preferenceManager.findPreference<SwitchPreference>(getString(R.string.appblock))
+        appBlockPreference?.setChecked(true)
+        //TODO: replace START and STOP buttons in app blocking screen
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference?) {

--- a/app/src/main/res/layout/fragment_appblocking.xml
+++ b/app/src/main/res/layout/fragment_appblocking.xml
@@ -29,38 +29,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/stop_foreground_service"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@color/colorPrimary"
-        android:paddingLeft="10dp"
-        android:paddingRight="10dp"
-        android:text="Stop service"
-        android:textColor="#fff"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/start_foreground_service"
-        app:layout_constraintTop_toBottomOf="@+id/view_timer"
-        app:layout_constraintVertical_bias="0.717" />
-
-    <Button
-        android:id="@+id/start_foreground_service"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@color/colorPrimary"
-        android:paddingLeft="10dp"
-        android:paddingRight="10dp"
-        android:text="Start service"
-        android:textColor="#fff"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/stop_foreground_service"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view_timer"
-        app:layout_constraintVertical_bias="0.717" />
-
     <TextView
         android:id="@+id/currently_blocked_app"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="title_activity_settings">Settings</string>
 
     <!-- Preference Keys -->
+    <string name="appblock">App Block</string>
     <string name="profile">Profile</string>
     <string name="restricted_apps">Restricted Apps</string>
     <string name="time_limit">Time Limit</string>
@@ -25,6 +26,9 @@
     <string name="profile_dialog_title">Enter Your Name</string>
 
     <!-- App Blocking Mode Preferences -->
+    <string name="appblock_title">App Blocking</string>
+    <string name="appblock_summary_on">App blocking enabled</string>
+    <string name="appblock_summary_off">App blocking disabled</string>
     <string name="restricted_apps_title">Select Apps to Restrict</string>
     <string name="restricted_apps_dialog">Apps to Restrict</string>
     <string name="smart_blocking_title">Smart Blocking</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -36,6 +36,14 @@
         app:iconSpaceReserved="false"
         app:title="@string/app_blocking_header">
 
+        <SwitchPreference
+            android:selectable="true"
+            app:iconSpaceReserved="false"
+            app:key="@string/appblock"
+            app:title="@string/appblock_title"
+            android:summaryOff="@string/appblock_summary_off"
+            android:summaryOn="@string/appblock_summary_on"/>
+
         <com.example.bluecatapp.ui.settings.RestrictAppsPreference
             android:defaultValue="@array/empty_array"
             app:iconSpaceReserved="false"


### PR DESCRIPTION
Add switch preferences to settings page to toggle app blocking.
Removed START and STOP buttons from app block screen.
App monitoring starts automatically when app blocking enabled in Settings.
